### PR TITLE
Add icon-only mode to World Clock plugin

### DIFF
--- a/WorldClockSettings.qml
+++ b/WorldClockSettings.qml
@@ -8,6 +8,13 @@ PluginSettings {
 
     pluginId: "worldClock"
 
+    ToggleSetting {
+        settingKey: "iconOnly"
+        label: "Icon Only"
+        description: "Display only a globe icon in the bar"
+        defaultValue: false
+    }
+
     ListSettingWithInput {
         settingKey: "timezones"
         label: "Timezones"

--- a/WorldClockWidget.qml
+++ b/WorldClockWidget.qml
@@ -11,11 +11,13 @@ PluginComponent {
     property var timezones: []
     property var pluginService: null
     property bool isLoading: true
+    property bool iconOnly: false
 
     function loadTimezones() {
         if (pluginService && pluginService.loadPluginData) {
             const saved = pluginService.loadPluginData("worldClock", "timezones", [])
             timezones = (saved && Array.isArray(saved)) ? saved : []
+            iconOnly = pluginService.loadPluginData("worldClock", "iconOnly", false) === true
             isLoading = false
         }
     }
@@ -40,12 +42,21 @@ PluginComponent {
         Row {
             spacing: Theme.spacingS
 
+            // Icon-only mode
+            StyledText {
+                text: "\u{1F310}\uFE0E" // Uses unicode symbol for cleaner look
+                font.pixelSize: Theme.fontSizeLarge
+                color: Theme.surfaceText
+                anchors.verticalCenter: parent.verticalCenter
+                visible: root.iconOnly
+            }
+
             // Loading spinner
             Item {
                 width: 16
                 height: 16
                 anchors.verticalCenter: parent.verticalCenter
-                visible: root.isLoading
+                visible: root.isLoading && !root.iconOnly
 
                 Rectangle {
                     id: spinner
@@ -78,7 +89,7 @@ PluginComponent {
             }
 
             Repeater {
-                model: root.timezones
+                model: root.iconOnly ? [] : root.timezones
 
                 StyledText {
                     text: {
@@ -110,7 +121,7 @@ PluginComponent {
                 font.pixelSize: Theme.fontSizeMedium
                 color: Theme.surfaceVariantText
                 anchors.verticalCenter: parent.verticalCenter
-                visible: !root.isLoading && root.timezones.length === 0
+                visible: !root.isLoading && root.timezones.length === 0 && !root.iconOnly
             }
         }
     }
@@ -119,12 +130,21 @@ PluginComponent {
         Column {
             spacing: Theme.spacingXS
 
+            // Icon-only mode
+            StyledText {
+                text: "\u{1F310}\uFE0E"
+                font.pixelSize: Theme.fontSizeLarge
+                color: Theme.surfaceText
+                anchors.horizontalCenter: parent.horizontalCenter
+                visible: root.iconOnly
+            }
+
             // Loading spinner
             Item {
                 width: 16
                 height: 16
                 anchors.horizontalCenter: parent.horizontalCenter
-                visible: root.isLoading
+                visible: root.isLoading && !root.iconOnly
 
                 Rectangle {
                     id: spinnerVertical
@@ -157,7 +177,7 @@ PluginComponent {
             }
 
             Repeater {
-                model: root.timezones
+                model: root.iconOnly ? [] : root.timezones
 
                 Column {
                     spacing: 1
@@ -194,7 +214,7 @@ PluginComponent {
                 font.pixelSize: Theme.fontSizeSmall
                 color: Theme.surfaceVariantText
                 anchors.horizontalCenter: parent.horizontalCenter
-                visible: !root.isLoading && root.timezones.length === 0
+                visible: !root.isLoading && root.timezones.length === 0 && !root.iconOnly
             }
         }
     }

--- a/plugin.json
+++ b/plugin.json
@@ -1,37 +1,38 @@
 {
-    "id": "worldClock",
-    "name": "World Clock",
-    "description": "Multiple timezones display widget",
-    "version": "1.0.0",
-    "author": "Bruno Cesar Rocha <rochacbruno>",
-    "icon": "public",
-    "component": "./WorldClockWidget.qml",
-    "settings": "./WorldClockSettings.qml",
-    "dependencies": {
-        "moment": {
-            "url": "https://cdn.jsdelivr.net/npm/moment@2.29.4/moment.min.js",
-            "optional": true
-        },
-        "moment-timezone": {
-            "url": "https://cdn.jsdelivr.net/npm/moment-timezone@0.5.43/builds/moment-timezone-with-data.min.js",
-            "optional": true
-        }
+  "id": "worldClock",
+  "name": "World Clock",
+  "description": "Multiple timezones display widget",
+  "version": "1.1.0",
+  "author": "Bruno Cesar Rocha <rochacbruno>",
+  "icon": "public",
+  "component": "./WorldClockWidget.qml",
+  "settings": "./WorldClockSettings.qml",
+  "dependencies": {
+    "moment": {
+      "url": "https://cdn.jsdelivr.net/npm/moment@2.29.4/moment.min.js",
+      "optional": true
     },
-    "settings_schema": {
-        "worldClockTimezones": {
-            "type": "array",
-            "default": [],
-            "items": {
-                "type": "object",
-                "properties": {
-                    "timezone": {"type": "string"},
-                    "label": {"type": "string"}
-                }
-            }
-        }
+    "moment-timezone": {
+      "url": "https://cdn.jsdelivr.net/npm/moment-timezone@0.5.43/builds/moment-timezone-with-data.min.js",
+      "optional": true
+    }
+  },
+  "settings_schema": {
+    "worldClockIconOnly": {
+      "type": "boolean",
+      "default": false
     },
-    "permissions": [
-        "settings_read",
-        "settings_write"
-    ]
+    "worldClockTimezones": {
+      "type": "array",
+      "default": [],
+      "items": {
+        "type": "object",
+        "properties": {
+          "timezone": { "type": "string" },
+          "label": { "type": "string" }
+        }
+      }
+    }
+  },
+  "permissions": ["settings_read", "settings_write"]
 }


### PR DESCRIPTION
Adds an option in plugin settings to enable an "icon only" mode, allowing users to create multiple timezones without overloading their bar.

<img width="447" height="274" alt="image" src="https://github.com/user-attachments/assets/65b3cc78-e7bf-4d63-bb75-7f6058e06c36" />
